### PR TITLE
Fix CookieOptionsConfiguration not setting the paths in CookieAuthenticationOptions (#22)

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/CookieOptionsConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/CookieOptionsConfiguration.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         {
             foreach (var mapping in _schemeOptions.Value.OpenIDMappings)
             {
-                if (mapping.Value.OpenIdConnectScheme == name)
+                if (mapping.Value.CookieScheme == name)
                 {
                     return mapping.Key;
                 }


### PR DESCRIPTION
This fixes #22. When configuring the CookieAuthenticationOptions, the scheme name is now correcly compared with the AzureAD Cookie Scheme name instead of the OpenID scheme name.