### PR TITLE
Proposes more flexible AzureADOptions, and defaulting to AzureAD v2.0

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/AzureADOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/AzureADOptions.cs
@@ -30,29 +30,47 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         public string JwtBearerSchemeName { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the client Id.
+        /// Gets or sets the client Id (Application Id) of the Azure AD application
         /// </summary>
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Gets or sets the client secret.
+        /// Gets or sets the audience for this Web Application or Web API (This audience needs
+        /// to match the audience of the tokens sent to access this application)
         /// </summary>
+        public string Audience { get; set; } = "api://{ClientId}";
+
+        /// <summary>
+        /// Gets or sets the client secret for the application
+        /// </summary>
+        /// <remarks>The client secret is only used if the Web app or Web API calls a Web
+        /// API</remarks>
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// Gets or sets the tenant Id.
+        /// Gets or sets the tenant. The tenant can have one of the following values:
+        /// <list type="table">
+        /// <item><term>a tenant ID</term><description>A GUID representing the ID of the Azure Active Directory Tenant</description></item>
+        /// <item><term>a domain</term><description>associated with Azure Active Directory</description></item>
+        /// <item><term>common</term><description>if the <see cref="Authority"/> is Azure AD v2.0, enables to sign-in users from any
+        /// Work and School account or Microsoft Personal Account. If Authority is Azure AD v1.0, enables sign-in from any Work and School accounts</description></item>
+        /// <item><term>organizations</term><description>if the <see cref="Authority"/> is Azure AD v2.0, enables to sign-in users from any
+        /// Work and School account</description></item>
+        /// <item><term>consumers</term><description>if the <see cref="Authority"/> is Azure AD v2.0, enables to sign-in users from any
+        /// Microsoft personal account</description></item>
+        /// </list>
         /// </summary>
-        public string TenantId { get; set; }
+        public string Tenant { get; set; } = "common";
 
         /// <summary>
         /// Gets or sets the Azure Active Directory instance.
         /// </summary>
-        public string Instance { get; set; }
+        public string Instance { get; set; } = "https://login.microsoftonline.com";
 
         /// <summary>
-        /// Gets or sets the domain of the Azure Active Directory tennant.
+        /// Azure AD Authority.
         /// </summary>
-        public string Domain { get; set; }
+        public string Authority { get; set; } = "https://{Instance}/{Tenant}/v2.0";
 
         /// <summary>
         /// Gets or sets the sign in callback path.

--- a/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/JwtBearerOptionsConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/JwtBearerOptionsConfiguration.cs
@@ -30,8 +30,12 @@ namespace Microsoft.AspNetCore.Authentication
                 return;
             }
 
-            options.Audience = azureADOptions.ClientId;
-            options.Authority = new Uri(new Uri(azureADOptions.Instance), azureADOptions.TenantId).ToString();
+            string audienceFormat = azureADOptions.Authority.Replace("{ClientId}", "{0}");
+            options.Audience = string.Format(audienceFormat, azureADOptions.ClientId);
+
+            string authorityFormat = azureADOptions.Authority.Replace("{Instance}", "{0}").Replace("{Tenant}", "{1}") ;
+            options.Authority = string.Format(authorityFormat, azureADOptions.Instance, azureADOptions.Tenant);
+
         }
 
         public void Configure(JwtBearerOptions options)

--- a/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/OpenIdConnectOptionsConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Authentication.AzureAD.UI/OpenIdConnectOptionsConfiguration.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
 
             options.ClientId = azureADOptions.ClientId;
             options.ClientSecret = azureADOptions.ClientSecret;
-            options.Authority = new Uri(new Uri(azureADOptions.Instance), azureADOptions.TenantId).ToString();
+            string authorityFormat = azureADOptions.Authority.Replace("{Instance}", "{0}").Replace("{Tenant}", "{1}");
+            options.Authority = string.Format(authorityFormat, azureADOptions.Instance, azureADOptions.Tenant);
             options.CallbackPath = azureADOptions.CallbackPath ?? options.CallbackPath;
             options.SignedOutCallbackPath = azureADOptions.SignedOutCallbackPath ?? options.SignedOutCallbackPath;
             options.SignInScheme = azureADOptions.CookieSchemeName;

--- a/test/Microsoft.AspNetCore.Authentication.AzureAD.FunctionalTests/ApiAuthenticationTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.AzureAD.FunctionalTests/ApiAuthenticationTests.cs
@@ -35,9 +35,8 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.FunctionalTests
                         .AddAzureADBearer(o =>
                         {
                             o.Instance = "https://login.microsoftonline.com/";
-                            o.Domain = "test.onmicrosoft.com";
+                            o.Tenant= "test.onmicrosoft.com";
                             o.ClientId = "ClientId";
-                            o.TenantId = "TenantId";
                         });
 
                     services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, o =>

--- a/test/Microsoft.AspNetCore.Authentication.AzureAD.FunctionalTests/WebAuthenticationTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.AzureAD.FunctionalTests/WebAuthenticationTests.cs
@@ -77,9 +77,8 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.FunctionalTests
                         .AddAzureAD(o =>
                         {
                             o.Instance = "https://login.microsoftonline.com/";
-                            o.Domain = "test.onmicrosoft.com";
+                            o.Tenant = "test.onmicrosoft.com";
                             o.ClientId = "ClientId";
-                            o.TenantId = "TenantId";
                         });
 
                     services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, o =>

--- a/test/Microsoft.AspNetCore.Authentication.AzureAD.UI.Test/AzureADAuthenticationBuilderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.AzureAD.UI.Test/AzureADAuthenticationBuilderExtensionsTests.cs
@@ -49,8 +49,7 @@ namespace Microsoft.AspNetCore.Authentication
                     o.ClientId = "ClientId";
                     o.ClientSecret = "ClientSecret";
                     o.CallbackPath = "/signin-oidc";
-                    o.Domain = "domain.onmicrosoft.com";
-                    o.TenantId = "Common";
+                    o.Tenant = "common";
                 });
             var provider = services.BuildServiceProvider();
 
@@ -64,7 +63,7 @@ namespace Microsoft.AspNetCore.Authentication
             Assert.Equal("ClientId", azureADOptions.ClientId);
             Assert.Equal("ClientSecret", azureADOptions.ClientSecret);
             Assert.Equal("/signin-oidc", azureADOptions.CallbackPath);
-            Assert.Equal("domain.onmicrosoft.com", azureADOptions.Domain);
+            Assert.Equal("common", azureADOptions.Tenant);
 
             var openIdOptionsMonitor = provider.GetService<IOptionsMonitor<OpenIdConnectOptions>>();
             Assert.NotNull(openIdOptionsMonitor);
@@ -176,8 +175,7 @@ namespace Microsoft.AspNetCore.Authentication
                     o.Instance = "https://login.microsoftonline.com/";
                     o.ClientId = "ClientId";
                     o.CallbackPath = "/signin-oidc";
-                    o.Domain = "domain.onmicrosoft.com";
-                    o.TenantId = "TenantId";
+                    o.Tenant = "domain.onmicrosoft.com";
                 });
             var provider = services.BuildServiceProvider();
 
@@ -188,7 +186,7 @@ namespace Microsoft.AspNetCore.Authentication
             Assert.Equal(AzureADDefaults.JwtBearerAuthenticationScheme, options.JwtBearerSchemeName);
             Assert.Equal("https://login.microsoftonline.com/", options.Instance);
             Assert.Equal("ClientId", options.ClientId);
-            Assert.Equal("domain.onmicrosoft.com", options.Domain);
+            Assert.Equal("domain.onmicrosoft.com", options.Tenant);
 
             var bearerOptionsMonitor = provider.GetService<IOptionsMonitor<JwtBearerOptions>>();
             Assert.NotNull(bearerOptionsMonitor);


### PR DESCRIPTION
Proposes improvements to the AzureADOptions:
- make it possible to specify the Audience of the tokens that will be accepted (with a default which is consistent with the Azure AD experience). For the moment it's hardcoded to {ClientId}
- make it possible to specity the Authority (for the moment it's hardcoded to {Instance}/{TenantId}. This is needed to make v2.0 primary without having users to have the change app generated by `dotnet new mvc`
- Proposing to remove Domain, and rename TenantId in Tenant as the tenant identification can be specified as a TenantID (a Guid), or a domain, or some well known "meta-tenants" (common, organizations and consumers)

Proposing that Web applications are now v2.0 apps by default.

Proposing improvements to the XML documentation

**Note that**
This PR is essentially to start the discussion. It's not mean to be final. In particular, no special effort was made for the tests yet